### PR TITLE
Delete Dappfile

### DIFF
--- a/Dappfile
+++ b/Dappfile
@@ -1,6 +1,0 @@
-name            ds-thing
-description
-version         0.0.1
-
-author          nikolai
-license         Apache-2.0


### PR DESCRIPTION
`Dappfile`s are [not used anymore](https://github.com/dapphub/dapptools/commit/99c1de109f93e8ca6bde1a91181a621efaab74fb) (and the license is wrong).